### PR TITLE
allow configuring 'repos' via config file

### DIFF
--- a/github2gitea
+++ b/github2gitea
@@ -377,7 +377,7 @@ class Github2Gitea(object):
 
         self.config = {
             k: v for k,v in vars(args).items()
-            if v not in [ None, False, 'false', 'False', []]
+            if v not in [ None, False, 'false', 'False', [] ]
         }
 
 if __name__ == '__main__':

--- a/github2gitea
+++ b/github2gitea
@@ -377,7 +377,7 @@ class Github2Gitea(object):
 
         self.config = {
             k: v for k,v in vars(args).items()
-            if v not in [ None, False, 'false', 'False' ]
+            if v not in [ None, False, 'false', 'False', []]
         }
 
 if __name__ == '__main__':


### PR DESCRIPTION
argparse sets <repos> to an empty list if parameter is not set. This
empty list is not updated later on.